### PR TITLE
Adding Directories

### DIFF
--- a/viewer/helpers.py
+++ b/viewer/helpers.py
@@ -1,5 +1,5 @@
 import os
-from typing import Tuple, List
+from typing import List, Tuple
 
 
 def extra_listdir(path: str) -> List[Tuple[str, str]]:
@@ -9,7 +9,14 @@ def extra_listdir(path: str) -> List[Tuple[str, str]]:
     :param path: The path to the directory.
     :return: A list of tuples, each containing two strings, the file or directory name, and the media type.
     """
-    return [(file, get_all_mediatype(file, path)) for file in os.listdir(path)]
+    files = []
+    for file in os.listdir(path):
+        mediatype = get_all_mediatype(file, path)
+        if mediatype == 'folder':
+            files.append((file, mediatype, os.path.join(path, file)))
+        else:
+            files.append((file, mediatype))
+    return files
 
 
 def get_all_mediatype(head: str, tail: str) -> str:

--- a/viewer/templates/add.html
+++ b/viewer/templates/add.html
@@ -17,7 +17,7 @@
                     <br>
                     Additionally, files can be matched <i>recursively</i> if you so wish. Please note that this functionality may create anomalous behavior around duplicate files.
                 </p>
-                <form action="{% url 'add_submit' %}">
+                <form action="{% url 'add_submit' %}" method="post">
                     {% csrf_token %}
                     <div class="field">
                         <label class="label">Directory</label>

--- a/viewer/templates/add.html
+++ b/viewer/templates/add.html
@@ -22,7 +22,7 @@
                     <div class="field">
                         <label class="label">Directory</label>
                         <div class="control has-icons-left has-icons-right">
-                            <input class="input" type="text" name="path" required placeholder="Full Path">
+                            <input class="input" type="text" name="path" required placeholder="Full Path"  {% if path_prefill %}value="{{ path_prefill }}"{% endif %}>
                             <span class="icon is-small is-left">
                                 <i class="fas fa-folder-open"></i>
                             </span>

--- a/viewer/templates/add.html
+++ b/viewer/templates/add.html
@@ -1,0 +1,64 @@
+{% extends 'base.html' %}
+{% block content %}
+    <div class="card">
+        <header class="card-header">
+            <p class="card-header-title">
+                Add New Directory
+            </p>
+        </header>
+        <div class="card-content">
+            <div class="content">
+                <p>
+                    Adds a new Directory to be served by the server.
+                    <br>
+                    If specified, a <a href="https://en.wikipedia.org/wiki/Regular_expression#Syntax">RegEx pattern</a> can be used to filter files and will only display the ones you want.
+                    <br>
+                    RegEx patterns can be configured below to match against the entire path or just the filename.
+                    <br>
+                    Additionally, files can be matched <i>recursively</i> if you so wish. Please note that this functionality may create anomalous behavior around duplicate files.
+                </p>
+                <form action="{% url 'add_submit' %}">
+                    {% csrf_token %}
+                    <div class="field">
+                        <label class="label">Directory</label>
+                        <div class="control has-icons-left has-icons-right">
+                            <input class="input" type="text" name="path" required placeholder="Full Path">
+                            <span class="icon is-small is-left">
+                                <i class="fas fa-folder-open"></i>
+                            </span>
+                        </div>
+                        <p class="help">
+                            We recommend that you use a full path. Do not escape the path or use a relative path for best results.
+                        </p>
+                    </div>
+                    <div class="field">
+                        <label class="label">Filter Files</label>
+                        <div class="control has-icons-left has-icons-right">
+                            <input class="input" type="text" name="regex" placeholder="RegEx Pattern">
+                            <span class="icon is-small is-left">
+                                <i class="fas fa-search"></i>
+                            </span>
+                        </div>
+                        <p class="help">
+                            This is optional. Do not enter anything if you wish to disable RegEx matching and simply add all files.
+                        </p>
+                    </div>
+                    <label class="checkbox pt-1 pb-3 pr-3">
+                        <input type="checkbox" name="match_filename">
+                        Match Against Filename?
+                    </label>
+                    <label class="checkbox pt-1 pb-3 pr-3">
+                        <input type="checkbox" name="recursive">
+                        Recursively Match
+                    </label>
+
+                    <div class="field">
+                        <div class="control">
+                            <button class="button is-link">Submit</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock content %}

--- a/viewer/templates/base.html
+++ b/viewer/templates/base.html
@@ -20,7 +20,9 @@
                 <div class="navbar-end">
                     <div class="navbar-item">
                         <span class="icon">
-                            <i class="fas fa-plus"></i>
+                            <a href="{% url 'add' %}">
+                                <i class="fas fa-plus"></i>
+                            </a>
                         </span>
                     </div>
                 </div>

--- a/viewer/templates/browse.html
+++ b/viewer/templates/browse.html
@@ -2,9 +2,9 @@
 {% block content %}
     <div class="panel">
         <div class="panel-heading">
-            Files
+            {{ directory.path }}
             <span style="font-weight: 400; font-style: italic; font-size: 70%;">
-                {{ files|length }}
+                {{ files|length }} files
             </span>
             <span style="vertical-align: middle;" class="panel-icon">
                 <a href="{% url 'index' %}">

--- a/viewer/templates/browse.html
+++ b/viewer/templates/browse.html
@@ -17,13 +17,22 @@
                         <span class="panel-icon pr-4">
                             <i class="fas fa-{{ file.1 }} fa-lg" aria-hidden="true"></i>
                         </span>
-                <a href="{% if file.1 != 'folder' %}{% url 'file' directory.id file.0 %}{% endif %}">
-                    {{ file.0 }}
-                </a>
+                {% if file.1 == 'folder' %}
+                    <a href="{% url 'add' %}?path={{ file.2 }}">
+                        {{ file.0 }}
+                    </a>
+                {% else %}
+                    <a href="{% url 'file' directory.id file.0 %}">
+                        {{ file.0 }}
+                        {{ file.0 }}
+                    </a>
+                {% endif %}
             </div>
         {% endfor %}
     </div>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js" integrity="sha512-bLT0Qm9VnAYZDflyKcBaQ2gg0hSYNQrJ8RilYldYQ1FxQYoCLtUjuuRuZo+fjqhx/qtq/1itJ0C2ejDxltZVFg==" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.5.1/jquery.min.js"
+            integrity="sha512-bLT0Qm9VnAYZDflyKcBaQ2gg0hSYNQrJ8RilYldYQ1FxQYoCLtUjuuRuZo+fjqhx/qtq/1itJ0C2ejDxltZVFg=="
+            crossorigin="anonymous"></script>
     {% load static %}
     <script src="{% static "hover.js" %}"></script>
 {% endblock content %}

--- a/viewer/templates/index.html
+++ b/viewer/templates/index.html
@@ -5,6 +5,12 @@
         .panel-icon {
             margin-right: 1em;
         }
+
+        .tag:not(body) {
+            font-size: 0.7rem;
+            line-height: 1.3;
+            padding: 0 0.6em;
+        }
     </style>
 {% endblock head %}
 {% block content %}
@@ -17,6 +23,9 @@
                         </span>
                 <a href="{% url 'browse' served_directory.id %}">
                     {{ served_directory.path }}
+                    {% if served_directory.regex %}
+                        <span class="tag is-info">Filtered</span>
+                    {% endif %}
                 </a>
             </div>
         {% endfor %}

--- a/viewer/urls.py
+++ b/viewer/urls.py
@@ -4,6 +4,8 @@ from . import views
 
 urlpatterns = [
     path('', views.index, name='index'),
-    path('/<uuid:directory_id>/', views.browse, name='browse'),
-    path('/<uuid:directory_id>/<str:file>/', views.file, name='file')
+    path('add/', views.add, name='add'),
+    path('add/submit', views.submit_new, name='add_submit'),
+    path('<uuid:directory_id>/', views.browse, name='browse'),
+    path('<uuid:directory_id>/<str:file>/', views.file, name='file')
 ]

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -58,7 +58,10 @@ def file(request, directory_id, file):
 
 
 def add(request):
-    return render(request, 'add.html', {'title': 'Add New Directory'})
+    context = {'title': 'Add New Directory'}
+    if 'path' in request.GET.keys():
+        context['path_prefill'] = request.GET['path']
+    return render(request, 'add.html', context)
 
 
 def submit_new(request):

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -1,7 +1,8 @@
 import os
 
-from django.http import FileResponse, HttpResponse
+from django.http import FileResponse, HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404
+from django.urls import reverse
 
 from viewer.helpers import extra_listdir
 from viewer.models import ServedDirectory
@@ -61,4 +62,25 @@ def add(request):
 
 
 def submit_new(request):
-    return HttpResponse('')
+    try:
+        s = ServedDirectory(
+            path=request.POST['path'],
+            regex_pattern=request.POST.get('regex'),
+            regex=request.POST.get('regex') is not None,
+            match_filename=request.POST.get('match_filename', False),
+            recursive=request.POST.get('recursive', False)
+        )
+        if not os.path.isdir(request.POST['path']):
+            raise ValueError('A invalid Directory was specified in the request.')
+        s.save()
+    except KeyError:
+        return render(request, 'message.html', status=403,
+                      context={'title': 'Invalid Options',
+                               'message': 'The POST request you sent did not have the options required to complete '
+                                          'the request.'})
+    except ValueError:
+        return render(request, 'message.html', status=400,
+                      context={'title': 'Invalid Directory',
+                               'message': 'The directory you specified was not a valid directory, either it doesn\'t '
+                                          'exist or it isn\'t a directory.'})
+    return HttpResponseRedirect(reverse('browse', args=(s.id,)))

--- a/viewer/views.py
+++ b/viewer/views.py
@@ -1,6 +1,6 @@
 import os
 
-from django.http import FileResponse
+from django.http import FileResponse, HttpResponse
 from django.shortcuts import render, get_object_or_404
 
 from viewer.helpers import extra_listdir
@@ -54,3 +54,11 @@ def file(request, directory_id, file):
         )
     }
     return render(request, 'message.html', context, status=500)
+
+
+def add(request):
+    return render(request, 'add.html', {'title': 'Add New Directory'})
+
+
+def submit_new(request):
+    return HttpResponse('')


### PR DESCRIPTION
This pull request should encapsulate directory adding capabilities.

- Frontend Directory Adding Form
    - The form should be complete and look nice, function well, and be as secure as an idiot like me can make it. Which just means I use the standard CSRF token given by Django. So secure.
- Backend Database Actions
    - The backend should handle processing the form submission with the CSRF token, add the new `ServedDirectory` object to the database and then redirect the user. Simple, but it should look into processing the RegEx options best. It should also reject invalid form inputs, like a invalid path.
- Database Shortcut
    - A shortcut should be added for directories found in other Served Directory listings. It should bring one to the *Add Directory* form, fill in the correct path, and nothing more. It would likely use simple query params in the URL.